### PR TITLE
Add parameters `ws_response_cls` and `ws_response_kwargs` to class `WsJsonRpcServer`

### DIFF
--- a/aiohttp_rpc/server/websocket.py
+++ b/aiohttp_rpc/server/websocket.py
@@ -16,16 +16,22 @@ __all__ = (
 
 class WsJsonRpcServer(BaseJsonRpcServer):
     rcp_websockets: weakref.WeakSet
+    ws_response_cls: typing.Type[web_ws.WebSocketResponse]
+    ws_response_kwargs: typing.Dict
     _json_response_handler: typing.Optional[typing.Callable] = None
     _background_tasks: typing.Set
 
     def __init__(self,
                  *args,
                  json_response_handler: typing.Optional[typing.Callable] = None,
+                 ws_response_cls: typing.Type[web_ws.WebSocketResponse] = web_ws.WebSocketResponse,
+                 ws_response_kwargs: typing.Optional[typing.Dict] = None,
                  **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         self.rcp_websockets = weakref.WeakSet()
+        self.ws_response_cls = ws_response_cls
+        self.ws_response_kwargs = ws_response_kwargs or {}
         self._json_response_handler = json_response_handler
         self._background_tasks = set()
 
@@ -46,7 +52,7 @@ class WsJsonRpcServer(BaseJsonRpcServer):
     async def _handle_ws_request(self, http_request: web.Request) -> web_ws.WebSocketResponse:
         from aiohttp_rpc import WsJsonRpcClient
 
-        ws_connect = web_ws.WebSocketResponse()
+        ws_connect = self.ws_response_cls(**self.ws_response_kwargs)
         await ws_connect.prepare(http_request)
 
         self.rcp_websockets.add(ws_connect)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,6 +1,8 @@
 import asyncio
 import datetime
 
+from aiohttp import web_ws
+
 import aiohttp_rpc
 from tests import utils
 
@@ -91,9 +93,9 @@ async def test_ws_client_for_server_response(aiohttp_client, mocker):
             future.set_result(results)
 
     async with aiohttp_rpc.WsJsonRpcClient(
-            '/rpc',
-            session=client,
-            json_request_handler=json_request_handler,
+        '/rpc',
+        session=client,
+        json_request_handler=json_request_handler,
     ) as rpc:
         json_request_handler = mocker.patch.object(rpc, '_json_request_handler', side_effect=rpc._json_request_handler)
         await rpc.method()
@@ -103,3 +105,44 @@ async def test_ws_client_for_server_response(aiohttp_client, mocker):
         assert results[0]['method'] == 'ping'
         assert results[1]['method'] == 'ping'
         assert results[2]['method'] == 'ping'
+
+
+async def test_ws_response_kwargs(aiohttp_client):
+    rpc_server = aiohttp_rpc.WsJsonRpcServer(
+        ws_response_kwargs=dict(
+            timeout=10.0,
+            max_msg_size=2048,
+        ),
+    )
+
+    client = await utils.make_ws_client(aiohttp_client, rpc_server)
+
+    async with aiohttp_rpc.WsJsonRpcClient(
+        '/rpc',
+        session=client,
+    ):
+        rpc_websocket: web_ws.WebSocketResponse
+        for rpc_websocket in rpc_server.rcp_websockets:
+            assert rpc_websocket._timeout == 10.0
+            assert rpc_websocket._max_msg_size == 2048
+
+
+async def test_ws_response_cls(aiohttp_client):
+    class CustomWebSocketResponse(web_ws.WebSocketResponse):
+        def __init__(self, **kwargs):
+            super().__init__(timeout=10.0, max_msg_size=2048, **kwargs)
+
+    rpc_server = aiohttp_rpc.WsJsonRpcServer(
+        ws_response_cls=CustomWebSocketResponse,
+    )
+
+    client = await utils.make_ws_client(aiohttp_client, rpc_server)
+
+    async with aiohttp_rpc.WsJsonRpcClient(
+        '/rpc',
+        session=client,
+    ):
+        for rpc_websocket in rpc_server.rcp_websockets:
+            assert isinstance(rpc_websocket, CustomWebSocketResponse)
+            assert rpc_websocket._timeout == 10.0
+            assert rpc_websocket._max_msg_size == 2048


### PR DESCRIPTION
Hello. 

I've added two parameters to the `WsJsonRpcServer`:
- `ws_response_cls` allows for using a custom subclass of `aiohttp.web_ws.WebSocketResponse`
- `ws_response_kwargs` allows to simply pass a dict of keyword args that are passed when constructing the `aiohttp.web_ws.WebSocketResponse`

This is in order to allow for customized response behaviour, for example modifying timeouts or enabling the heartbeat/ping-pong mechanism, which is essential to any advanced server usage. I saw my websockets connections drop to my production instance all the time, and I found out that the heartbeat mechanism in `aiohttp` was simply not enabled and there was no way to enable it in the current version. I'm not quite sure why it's disabled by default in `aiohttp` anyway, since it's required by many clients to keep a websockets connection open.

So I've added two options to customize it, hoping it will help more developers in the future.